### PR TITLE
fix: Update iOS application name on launcher

### DIFF
--- a/ios/SpaceExplorer/Info.plist
+++ b/ios/SpaceExplorer/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>SpaceExplorer</string>
+	<string>Space Explorer</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Changed iOS app display name from SpaceExplorer to Space Explorer in the app launcher.